### PR TITLE
Improve robustness and edge cond handling

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -56,6 +57,7 @@ func TestSucceedIfSelfSignedCA(t *testing.T) {
 			}},
 	}
 	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode("{}")
 	}))
 	defer target.Close()
 
@@ -73,6 +75,7 @@ func TestSucceedIfSelfSignedCA(t *testing.T) {
 
 func TestDefaultModule(t *testing.T) {
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode("{}")
 	}))
 	defer target.Close()
 
@@ -114,6 +117,7 @@ func TestDefaultAcceptHeader(t *testing.T) {
 			t.Errorf("Default 'Accept' header mismatch, got %s, expected: %s", got, expected)
 			w.WriteHeader(http.StatusNotAcceptable)
 		}
+		json.NewEncoder(w).Encode("{}")
 	}))
 	defer target.Close()
 
@@ -173,6 +177,8 @@ func TestBasicAuth(t *testing.T) {
 			t.Errorf("BasicAuth mismatch, got: %s, expected: %s", got, expected)
 			w.WriteHeader(http.StatusUnauthorized)
 		}
+
+		json.NewEncoder(w).Encode("{}")
 	}))
 	defer target.Close()
 
@@ -209,6 +215,8 @@ func TestBearerToken(t *testing.T) {
 			t.Errorf("BearerToken mismatch, got: %s, expected: %s", got, expected)
 			w.WriteHeader(http.StatusUnauthorized)
 		}
+
+		json.NewEncoder(w).Encode("{}")
 	}))
 	defer target.Close()
 
@@ -245,6 +253,7 @@ func TestHTTPHeaders(t *testing.T) {
 			}
 		}
 		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode("{}")
 	}))
 	defer target.Close()
 
@@ -309,6 +318,7 @@ func TestBodyPostTemplate(t *testing.T) {
 				t.Errorf("POST request body content mismatch, got: %s, expected: %s", got, expected)
 			}
 			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode("{}")
 		}))
 
 		req := httptest.NewRequest("POST", "http://example.com/foo"+"?module=default&target="+target.URL, strings.NewReader(test.Body.Content))
@@ -402,6 +412,7 @@ func TestBodyPostQuery(t *testing.T) {
 				t.Errorf("POST request body content mismatch (with query params), got: %s, expected: %s", got, expected)
 			}
 			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode("{}")
 		}))
 
 		req := httptest.NewRequest("POST", "http://example.com/foo"+"?module=default&target="+target.URL, strings.NewReader(test.Body.Content))

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"io/ioutil"
+	"time"
 
 	pconfig "github.com/prometheus/common/config"
 	"gopkg.in/yaml.v2"
@@ -53,6 +54,7 @@ const (
 // Config contains multiple modules.
 type Config struct {
 	Modules map[string]Module `yaml:"modules"`
+	Request Request           `yaml:"request"`
 }
 
 // Module contains metrics and headers defining a configuration
@@ -67,6 +69,10 @@ type Module struct {
 type Body struct {
 	Content    string `yaml:"content"`
 	Templatize bool   `yaml:"templatize,omitempty"`
+}
+
+type Request struct {
+	TimeoutSeconds time.Duration `yaml:"timeoutSeconds"`
 }
 
 func LoadConfig(configPath string) (Config, error) {

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -64,3 +64,6 @@ modules:
 
     # Accepted status codes for this probe. Defaults to 2xx.
     # valid_status_codes: [ <int>, ... | default = 2xx ]
+
+request:
+  timeoutSeconds: 20

--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -44,7 +44,11 @@ type JSONMetric struct {
 	EpochTimestampJSONPath string
 }
 
+var jsonExporterStatusDesc *prometheus.Desc = prometheus.NewDesc("json_exporter_status", "Up/Down Status of JSON Exporter. Should always be 0.", nil, nil)
+
 func (mc JSONMetricCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- jsonExporterStatusDesc
+
 	for _, m := range mc.JSONMetrics {
 		ch <- m.Desc
 	}
@@ -52,6 +56,12 @@ func (mc JSONMetricCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (mc JSONMetricCollector) Collect(ch chan<- prometheus.Metric) {
 	var rootData []byte = mc.Data
+
+	ch <- prometheus.MustNewConstMetric(
+		jsonExporterStatusDesc,
+		prometheus.GaugeValue,
+		0,
+	)
 
 	for _, m := range mc.JSONMetrics {
 		switch m.Type {
@@ -64,7 +74,6 @@ func (mc JSONMetricCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			if floatValue, err := SanitizeValue(value); err == nil {
-
 				ch <- prometheus.MustNewConstMetric(
 					m.Desc,
 					m.ValueType,

--- a/test/response/good.txt
+++ b/test/response/good.txt
@@ -13,3 +13,6 @@ example_value_boolean{environment="beta",id="id-C"} 0
 # TYPE example_value_count counter
 example_value_count{environment="beta",id="id-A"} 1
 example_value_count{environment="beta",id="id-C"} 3
+# HELP json_exporter_status Up/Down Status of JSON Exporter. Should always be 0.
+# TYPE json_exporter_status gauge
+json_exporter_status 0

--- a/test/response/test-converter.txt
+++ b/test/response/test-converter.txt
@@ -27,3 +27,6 @@ test8_active{name="Test Converter"} 2
 # HELP test8_stat Testing Multi Diff Value Converter on Type Object
 # TYPE test8_stat untyped
 test8_stat{name="Test Converter"} 1
+# HELP json_exporter_status Up/Down Status of JSON Exporter. Should always be 0.
+# TYPE json_exporter_status gauge
+json_exporter_status 0


### PR DESCRIPTION
Updates include:

- Adding json_exporter_status as a metric
- Adding timeout configuration for outgoing request
- Request will return 503 failure response when the endpoint response (to be converted) is not a JSON formatted message
- Update test to reflect changes in behavior

Manually tested several scenario and ran updated test to ensure automated test passed.